### PR TITLE
Bump @anthropic-ai/claude-code from 1.0.61 to 2.1.120

### DIFF
--- a/base-action/action.yml
+++ b/base-action/action.yml
@@ -115,7 +115,7 @@ runs:
 
     - name: Install Claude Code
       shell: bash
-      run: bun install -g @anthropic-ai/claude-code@1.0.61
+      run: bun install -g @anthropic-ai/claude-code@2.1.120
 
     - name: Run Claude Code Action
       shell: bash


### PR DESCRIPTION
Bumps the pinned claude-code CLI to the current latest release (published 2026-04-24).

The previous pin (`1.0.61`) is roughly a year stale and is missing all the agent-loop, tool, and model-handling improvements landed in `2.x`. The bump is a single line in `base-action/action.yml`.

No other changes.